### PR TITLE
Menus table new column migration ifix 76

### DIFF
--- a/database/migrations/2019_09_21_054211_add_created_at_to_menus_table.php
+++ b/database/migrations/2019_09_21_054211_add_created_at_to_menus_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCreatedAtToMenusTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            //
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            //
+            $table->dropColumn('created_at');
+        });
+    }
+}


### PR DESCRIPTION
As created_at column was messing from the online server this migration will resolve this issue https://github.com/ddlibrary/website/issues/76