### PR TITLE
Fix admin user delete leaving back orphaned data

### DIFF
--- a/app/UserProfile.php
+++ b/app/UserProfile.php
@@ -4,6 +4,17 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property mixed      user_id
+ * @property mixed      first_name
+ * @property mixed      last_name
+ * @property mixed      country
+ * @property mixed|null city
+ * @property mixed      gender
+ * @property mixed      phone
+ * @method static find($userId)
+ * @method static where(string $string, $userId)
+ */
 class UserProfile extends Model
 {
     /**

--- a/app/UserRole.php
+++ b/app/UserRole.php
@@ -4,6 +4,12 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property mixed     user_id
+ * @property int|mixed role_id
+ * @method static find($userId)
+ * @method static where(string $string, $userId)
+ */
 class UserRole extends Model
 {
     /**

--- a/database/migrations/2020_06_17_084458_add_primary_key_id_to_user_roles.php
+++ b/database/migrations/2020_06_17_084458_add_primary_key_id_to_user_roles.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPrimaryKeyIdToUserRoles extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('user_roles', function (Blueprint $table) {
+            $table->increments('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('user_roles', function (Blueprint $table) {
+            $table->dropColumn('id');
+        });
+    }
+}

--- a/resources/views/admin/users/users.blade.php
+++ b/resources/views/admin/users/users.blade.php
@@ -83,14 +83,14 @@
             @foreach ($users as $indexkey => $user)
               <tr>
                 <td>{{ (($users->currentPage() - 1) * $users->perPage())+$indexkey + 1 }}</td>
-                <td><a href="{{URL::to('user/'.$user->id) }}">{{ $user->username }}</a><br>{{ $user->email }}</td>
+                <td><a href="{{ URL::to('admin/user/edit/'.$user->id) }}">{{ $user->username }}</a><br>{{ $user->email }}</td>
                 <td>{{ ($user->status==0?"Not Active":"Active") }}</td>
                 <td>{{ $user->all_roles }}</td>
                 <td>{{ \Carbon\Carbon::parse($user->created_at)->diffForHumans() }}</td>
                 <td>{{ \Carbon\Carbon::parse($user->accessed_at)->diffForHumans() }}</td>
                 <td>
-                  <a href="user/edit/{{$user->id}}">Edit</a> | 
-                  <a href="user/delete/{{$user->id}}" onclick="return confirm('Are you sure you want to delete this user?');">Delete</a>
+                  <a href="{{ URL::to('admin/user/edit/'.$user->id) }}">Edit</a> |
+                  <a href="{{ URL::to('admin/user/delete/'.$user->id) }}" onclick="return confirm('Are you sure you want to delete this user?');">Delete</a>
                 </td>
               </tr>
               @endforeach


### PR DESCRIPTION
While working on the registration form, came across the bit where deleting a user on admin leaves back bits and pieces here and there. Managed to add code to remove the corresponding records from `user_profiles` and `user_roles`. We should've added `->onDelete('cascade');` to the `user_id` foreign keys (`user_id` in `user_roles` apparently is not a foreign key), but included a migration to add a primary key to `user_roles` so that we at least get to delete the record.
    1. I'm yet to figure out what we could do about the `user_id` non-nullable field in the `Resources` model. Open to thoughts and comments on this.

Also, clicking the username on admin takes you to a page that doesn't exist. Now, it takes you to the edit page.