### PR TITLE
Make reCAPTCHA required

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -87,7 +87,7 @@ class RegisterController extends Controller
                 'gender' => 'required',
                 'country' => 'required',
                 'city' => 'nullable',
-                'g-recaptcha-response' => 'sometimes|required|captcha'
+                'g-recaptcha-response' => 'required|captcha'
             ],
             $messages = [
                 'phone.unique' => __('The phone number has already been taken.'),

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -69,7 +69,7 @@ class ContactController extends Controller
             'email'     => 'required|email',
             'subject'   => 'required',
             'message'   => 'required',
-            'g-recaptcha-response' => 'sometimes|required|captcha'
+            'g-recaptcha-response' => 'required|captcha'
         ]);
 
         //Saving contact info to the database


### PR DESCRIPTION
Having `sometimes` in the validation of captcha makes it easy to circumvent it by just popping it from the form, defeating the whole purpose behind having captcha. Since we keep getting illegitimate and spam users, I'm making the field mandatory.  