### PR TITLE
Add ipv6 support for viewing resources [DDL-61]

### DIFF
--- a/database/migrations/2021_05_05_051228_change_ip_size_in_resource_views_table.php
+++ b/database/migrations/2021_05_05_051228_change_ip_size_in_resource_views_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeIpSizeInResourceViewsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('resource_views', function ($table) {
+            $table->string('ip', 64)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('resource_views', function ($table) {
+            $table->string('ip', 32)->change();
+        });
+    }
+}


### PR DESCRIPTION
We record users' IP addresses when they visit individual resources. This works fine for users on IPv4 addresses, but doesn't work as intended for users on IPv6 since the database column is only meant for strings less than 32 characters. Expand it to 64 characters.